### PR TITLE
Add site directory link to Cyberdeck helper

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,3 +1,16 @@
-<html><head>
-<meta name="google-adsense-account" content="ca-pub-7896945483758478">
-</head></html>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Site Directory</title>
+  <meta name="google-adsense-account" content="ca-pub-7896945483758478">
+</head>
+<body>
+  <main>
+    <h1>Site Directory</h1>
+    <ul>
+      <li><a href="https://drjaul.github.io/Cyberdeck">Cyberdeck Configuration Helper</a></li>
+    </ul>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a simple directory landing page
- add a link to the Cyberdeck Configuration Helper

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68cafc7ac52883249bd460ede46f168f