### PR TITLE
Tighten privacy modal layout

### DIFF
--- a/assets/css/consent.css
+++ b/assets/css/consent.css
@@ -18,12 +18,7 @@
   max-width: 960px;
   margin: 0 auto;
   display: grid;
-  gap: 1rem;
-}
-
-.consent-banner h3 {
-  margin: 0;
-  font-size: 1.1rem;
+  gap: 0.75rem;
 }
 
 .consent-banner p {
@@ -39,7 +34,7 @@
 }
 
 .consent-actions button {
-  padding: 0.5rem 1rem;
+  padding: 0.375rem 0.75rem;
   border-radius: 0.75rem;
   border: 1px solid rgba(255, 255, 255, 0.25);
   background: rgba(255, 255, 255, 0.08);
@@ -68,27 +63,29 @@
   background: rgba(7, 11, 18, 0.9);
   border-radius: 1rem;
   border: 1px solid rgba(255, 255, 255, 0.12);
-  padding: 1rem;
+  padding: 0.75rem;
 }
 
 .consent-options {
   display: grid;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .consent-option {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.75rem;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  padding: 0.5rem;
   border-radius: 0.75rem;
   background: rgba(255, 255, 255, 0.05);
+  min-height: 100%;
 }
 
 .consent-option label {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 @media (max-width: 640px) {
@@ -99,6 +96,7 @@
   .consent-option {
     flex-direction: column;
     align-items: flex-start;
+    gap: 0.35rem;
   }
 
   .consent-actions {

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -74,8 +74,7 @@
 
   <div class="consent-banner" role="dialog" aria-modal="true" aria-hidden="true" aria-live="polite">
     <div class="consent-inner">
-      <h3>We value your privacy</h3>
-      <p>Project Directory uses cookies and localStorage to remember tool settings. Google may use cookies to personalize or measure ads if you give consent. You can update your choice at any time.</p>
+      <p><strong>We value your privacy.</strong> Project Directory uses cookies and localStorage to remember tool settings. Google may use cookies to personalize or measure ads if you give consent. You can update your choice at any time.</p>
       <div class="consent-actions">
         <button type="button" class="primary" data-consent-action="accept">Accept all</button>
         <button type="button" class="secondary" data-consent-action="reject">Reject all</button>


### PR DESCRIPTION
## Summary
- shrink the consent modal buttons and tighten spacing for a lower profile banner
- restructure the manage panel layout to reduce its height while keeping options visible
- remove the modal heading and fold the message into the lead paragraph

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd87ca9e248324980cb7e17de4fef9